### PR TITLE
Fix reporting nil error caused by wrapping nil instance

### DIFF
--- a/domain/issue/domain.go
+++ b/domain/issue/domain.go
@@ -62,7 +62,7 @@ func (is *issueServiceImpl) render(ctx context.Context, templateIssueURL string)
 	}
 
 	if len(_templateIssue.Labels) == 0 {
-		return types.Issue{}, errors.Wrap(err, "Requires at least one label")
+		return types.Issue{}, errors.New("Requires at least one label")
 	}
 
 	lastIssue, err := is.ir.FindLastIssueByLabel(ctx, _templateIssue)


### PR DESCRIPTION
`issue-creator` dumps inappropriate error message when it failed to create an issue that no label was attached to.
It was due to wrong error handling, so I've fixed it.