### PR TITLE
Tweak the descriptions of inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,10 +2,10 @@ name: 'issue-creator'
 description: 'Periodically create GitHub issue'
 inputs:
   template-issue:
-    description: 'template issue number, e.g.1.  https://github.com/rerost/issue-creator/issues/1'
+    description: 'Specify the issue number of the template in the repository. e.g. 1'
     required: true
   close-last-issue:
-    description: 'close prev issue or not'
+    description: 'If true, issue-creator closes the previous issue.'
     default: true
   check-before-create-issue:
     description: 'shell script'


### PR DESCRIPTION
## Why

When I was tried to use the Actions on my repo, I was specified an URL of the issue template to `template-issue` as described in `template-issue` description, and I got an error "Failed to parse url".
After that, I noticed that I must specify only the number of the template issue to `template-issue`.

The description is a bit confusable so I'd like to tweak the description.


