### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19
+FROM golang:1.19-alpine
 
 WORKDIR $GOPATH/src/github.com/rerost/issue-creator
 

--- a/action.sh
+++ b/action.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 repository=$1
 template_issue=$2
@@ -16,7 +16,7 @@ fi
 url=https://github.com/${repository}/${type}/${template_issue}
 echo ${url}
 
-issue-creator \
+./issue-creator \
   create \
   ${url} \
   --CloseLastIssue=${close_last_issue} \

--- a/domain/issue/domain.go
+++ b/domain/issue/domain.go
@@ -129,7 +129,7 @@ func (is *issueServiceImpl) Create(ctx context.Context, templateURL string) (typ
 		f.Chmod(0755)
 		f.Close()
 
-		out, err := exec.Command("bash", f.Name()).Output()
+		out, err := exec.Command("sh", f.Name()).Output()
 		if err != nil {
 			zap.L().Error("Failed to exec check before create issue", zap.String("out", string(out)), zap.String("err", err.Error()))
 			return types.Issue{}, errors.WithStack(err)


### PR DESCRIPTION
## Why
issue-creator is too slow(about 40s) in GitHub Action

<details>

```
#6 [1/8] FROM docker.io/library/golang:1.19@sha256:d680597c753e7c73814ddd09c69bef5b78922d81d3ca103c82fa69771ea8151c
  #6 resolve docker.io/library/golang:1.19@sha256:d680597c753e7c73814ddd09c69bef5b78922d81d3ca103c82fa69771ea8151c 0.0s done
  #6 sha256:d680597c753e7c73814ddd09c69bef5b78922d81d3ca103c82fa69771ea8151c 2.36kB / 2.36kB done
  #6 sha256:ddbb6cbbc88a5e8d802c3ab7dc717d7a0634401c030266f4ff0f1933806f2ed9 1.58kB / 1.58kB done
  #6 sha256:b95d19c099a72b58815ea493d7a974fda5737140e7999cd16b98da643c9bf93d 6.87kB / 6.87kB done
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 0B / 92.27MB 0.1s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 0B / 149.15MB 0.1s
  #6 sha256:75336b934c7e78a6147e6a0b26908a840a1b8bff751c8c4a84e949b2626f7[85](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:85)b 0B / 157B 0.1s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d[87](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:87)24edaa97928 14.[31](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:31)MB / 149.15MB 0.3s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 26.21MB / 149.15MB 0.4s
  #6 sha256:75336b934c7e78a6147e6a0b26908a840a1b8bff751c8c4a84e949b2626f785b 157B / 157B 0.3s done
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d[32](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:32)fc07d031a408 18.87MB / 92.27MB 0.5s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 42.99MB / 149.15MB 0.5s
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 53.48MB / 92.27MB 0.7s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 62.91MB / 149.15MB 0.7s
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 67.11MB / 92.27MB 0.8s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 71.30MB / 149.15MB 0.8s
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 79.69MB / 92.27MB 0.9s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 80.74MB / 149.15MB 0.9s
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 85.98MB / 92.27MB 1.0s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 90.18MB / 149.15MB 1.0s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 120.59MB / 149.15MB 1.2s
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 92.27MB / 92.27MB 1.3s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 139.46MB / 149.15MB 1.3s
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 149.15MB / 149.15MB 1.4s
  #6 sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 92.27MB / 92.27MB 1.4s done
  #6 sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 149.15MB / 149.15MB 2.2s done
  #6 extracting sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408
  #6 extracting sha256:9e59e6b803ed24f34e9d1001d46221a69fa46b48d7d007de7d32fc07d031a408 2.8s done
  #6 extracting sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928
  #6 extracting sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 5.1s
  #6 extracting sha256:8bd65fbd049e2229dd793902bfe936a37f8f73d3f926ac7a55d8724edaa97928 5.4s done
  #6 extracting sha256:75[33](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:33)6b9[34](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:34)c7e78a6147e6a0b26908a840a1b8bff751c8c4a84e949b2626f785b done
  #6 DONE 14.1s
  
  #7 [2/8] WORKDIR /go/src/github.com/rerost/issue-creator
  #7 DONE 0.0s
  
  #8 [3/8] COPY go.mod .
  #8 DONE 0.0s
  
  #9 [4/8] COPY go.sum .
  #9 DONE 0.0s
  
  #10 [5/8] RUN go mod download
  #10 DONE 3.8s
  
  #11 [6/8] COPY . .
  #11 DONE 0.0s
  
  #12 [7/8] RUN go install
  #12 DONE 10.1s
  
  #13 [8/8] COPY action.sh /action.sh
  #13 DONE 0.1s
  
  #14 exporting to image
  #14 exporting layers
  #14 exporting layers 5.8s done
  #14 writing image sha256:0596034f419bb22579eb78f45faeb78edc1f4e93a69b783449857a6fe[39](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:39)1fdc1 done
  #14 naming to docker.io/library/5bedb4:12[45](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:45)80df85974[56](https://gith
ub.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:56)fa2c2[70](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:2:70)333f2af898 done
  #[1](https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377#step:3:1)4 DONE 5.8s
```

</details>

## What
- [x] Reduce docker pull time by use alpine image

[logs_23.zip](https://github.com/rerost/issue-creator/files/12321684/logs_23.zip)
https://github.com/rerost/issue-creator/actions/runs/5832847513/job/15819045377