### PR TITLE
Rerost/fix docker image problem

### DIFF
--- a/Dockerfile.actions
+++ b/Dockerfile.actions
@@ -1,0 +1,2 @@
+# commit_hash: 91e3b4b67ebfdd2709d531866ff68b15f76808dc
+FROM ghcr.io/rerost/issue-creator@sha256:8e6929e4bc157a5ad19b4f0c81de3518f29d3250af9569b8681522849a1eb447

--- a/Dockerfile.actions
+++ b/Dockerfile.actions
@@ -1,2 +1,1 @@
-# commit_hash: 91e3b4b67ebfdd2709d531866ff68b15f76808dc
-FROM ghcr.io/rerost/issue-creator@sha256:8e6929e4bc157a5ad19b4f0c81de3518f29d3250af9569b8681522849a1eb447
+FROM ghcr.io/rerost/issue-creator@TAG

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: ${{ github.repository }}
 runs:
   using: "docker"
-  image: 'rerost/issue-creator@sha256:a27341a35933d82735fc2e6ec0ac23b159a8b319c18d49cd1396f241d0ee9569' # commit: https://github.com/rerost/issue-creator/pull/108/commits/14fab538950c46f91b81e4e2037e4e2abf5d5f1c
+  image: 'ghcr.io/rerost/issue-creator@sha256:8e6929e4bc157a5ad19b4f0c81de3518f29d3250af9569b8681522849a1eb447' # commit_hash: 91e3b4b67ebfdd2709d531866ff68b15f76808dc
   args:
     - ${{ inputs.repository }}
     - ${{ inputs.template-issue }}

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: ${{ github.repository }}
 runs:
   using: "docker"
-  image: 'ghcr.io/rerost/issue-creator@sha256:8e6929e4bc157a5ad19b4f0c81de3518f29d3250af9569b8681522849a1eb447' # commit_hash: 91e3b4b67ebfdd2709d531866ff68b15f76808dc
+  image: 'Dockerfile.actions'
   args:
     - ${{ inputs.repository }}
     - ${{ inputs.template-issue }}

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -eu
+
+if [ $# -ne 1 ]; then
+  echo "Requrire tag. e.g. v0.3.0"
+  exit 1
+fi
+
+tag=$1
+
+# Actions が利用できるDocker Imageの制限に対応するため。 https://stackoverflow.com/questions/76403845/when-accessing-github-marketplace-actions-i-am-seeing-getting-error-should-be-e 
+echo "tag: $tag"
+git checkout master
+git pull origin master
+# Only mac
+sed -i '' 's/TAG/new_string/g' Dockerfile.actions
+git add Dockerfile.actions
+git commit -m "Generate docker file"
+git push origin master
+git tag -a $tag -m "$tag"
+git push origin $tag


### PR DESCRIPTION
## Why
Avoid actions can't directory use docker image problem

> Error: 'rerost/issue-creator@sha256:a27341a35933d82735fc2e6ec0ac23b159a8b319c18d49cd1396f241d0ee9569' should be either '[path]/Dockerfile' or 'docker://image[:tag]'.

https://stackoverflow.com/questions/76403845/when-accessing-github-marketplace-actions-i-am-seeing-getting-error-should-be-e

cf. https://github.com/rerost/issue-creator/issues/98

## What
- [x] use `Dockerfile.actions` and depends by `FROM` to ghcr builded docker image