### PR TITLE
Do not use shared Discussion

### DIFF
--- a/repo/discussion.go
+++ b/repo/discussion.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rerost/issue-creator/types"
@@ -128,6 +129,10 @@ func (r *discussionRepositoryImpl) Create(ctx context.Context, issue types.Issue
 			Discussion `graphql:"... on Discussion"`
 		} `graphql:"node(id: $id)"`
 	}
+
+	// Discussion作成 -> ラベル付与 -> Discussionの取得という流れだが、たまにラベルが付与される前のDiscussionを読み取る場合がある
+	// そのためのSleep
+	time.Sleep(time.Second)
 
 	err = r.ghc.Query(
 		ctx,


### PR DESCRIPTION
2つ同時にテストが動くと、片方のテストが落ちる

```
--- PASS: TestFindByURL (0.00s)
    --- PASS: TestFindByURL/#00 (0.26s)
--- PASS: TestIssueFindLastIssue (0.39s)
=== NAME  TestCloseByURL/#00
    discussion_test.go:2[75](https://github.com/rerost/issue-creator/actions/runs/10440886388/job/28911339857#step:4:76): https://github.com/rerost/issue-creator-for-test/discussions/4 is already closed
--- PASS: TestFindLastIssue (0.00s)
    --- PASS: TestFindLastIssue/#00 (0.34s)
=== NAME  TestCloseByURL/#00
    discussion_test.go:292: https://github.com/rerost/issue-creator-for-test/discussions/4 is not close
--- FAIL: TestCloseByURL (0.00s)
    --- FAIL: TestCloseByURL/#00 (1.84s)
--- PASS: TestCreate (0.00s)
    --- PASS: TestCreate/#00 (1.95s)
```



https://github.com/rerost/issue-creator/actions/runs/10440886388/job/28911339857